### PR TITLE
Ruby 1.9 Encoding Required

### DIFF
--- a/lib/em-websocket/framing76.rb
+++ b/lib/em-websocket/framing76.rb
@@ -1,3 +1,5 @@
+# encoding: BINARY
+
 module EventMachine
   module WebSocket
     module Framing76


### PR DESCRIPTION
Without the proper encoding header, Ruby 1.9 will not work. It will complain about the character set used in the regexp for the Websocket component, as `\xFF` is not valid UTF-8.
