### PR TITLE
Slight HandlerFactory modification

### DIFF
--- a/lib/em-websocket/handler_factory.rb
+++ b/lib/em-websocket/handler_factory.rb
@@ -33,6 +33,10 @@ module EventMachine
           request[h[1].strip] = h[2].strip if h
         end
 
+        build_with_request(connection, request, remains, secure, debug)
+      end
+
+      def self.build_with_request(connection, request, remains, secure = false, debug = false)
         version = request['Sec-WebSocket-Key1'] ? 76 : 75
         case version
         when 75


### PR DESCRIPTION
In order to reuse the HandlerFactory in another project I need to be able to call with passing the headers in as a string. This breaks the build method into 2 parts allowing me to provide an already assembled 'request' hash.
