### PR TITLE
Better Debugger module.

### DIFF
--- a/lib/em-websocket/debugger.rb
+++ b/lib/em-websocket/debugger.rb
@@ -9,6 +9,9 @@ module EventMachine
         if @debug || data.first == :error
           require 'pp'
           pp data
+          data.each do |datum|
+            puts datum.backtrace if datum.respond_to?(:backtrace)
+          end
           puts
         end
       end


### PR DESCRIPTION
I was writing a little websocket server using em-websockets, but it was hard for me to debug my program for two reasons:

1) I was not notified of exceptions thrown by my code by default (I know I could use the :debug=>true option but that gives me a lot more output than I need).
2) Even if I was notified of an exception, there was no backtrace provided so it was nearly impossible to tell where in my code the exception came from.

My fork of em-websocket provides two commits that fix these problems.

P.S.  Good job on the gem, it was very easy for me to get started using it.
