### PR TITLE
Update for WebSocket protocol revisions 7 and 8

### DIFF
--- a/lib/em-websocket.rb
+++ b/lib/em-websocket.rb
@@ -5,11 +5,11 @@ require "eventmachine"
 %w[
   debugger websocket connection
   handshake75 handshake76 handshake04
-  framing76 framing03 framing04 framing05
+  framing76 framing03 framing04 framing05 framing08
   close75 close03 close05 close06
   masking04
   message_processor_03 message_processor_06
-  handler_factory handler handler75 handler76 handler03 handler05 handler06
+  handler_factory handler handler75 handler76 handler03 handler05 handler06 handler08
 ].each do |file|
   require "em-websocket/#{file}"
 end

--- a/lib/em-websocket/framing08.rb
+++ b/lib/em-websocket/framing08.rb
@@ -1,0 +1,159 @@
+# encoding: BINARY
+
+module EventMachine
+  module WebSocket
+    module Framing08
+
+      def initialize_framing
+        @data = MaskedString.new
+        @application_data_buffer = '' # Used for MORE frames
+      end
+
+      def process_data(newdata)
+        error = false
+
+        while !error && @data.size > 5 # mask plus first byte present
+          pointer = 0
+
+          @data.read_mask
+
+          fin = (@data.getbyte(pointer) & 0b10000000) == 0b10000000
+          # Ignoring rsv1-3 for now
+          opcode = @data.getbyte(pointer) & 0b00001111
+          pointer += 1
+
+          # Ignoring rsv4
+          length = @data.getbyte(pointer) & 0b01111111
+          pointer += 1
+
+          payload_length = case length
+          when 127 # Length defined by 8 bytes
+            # Check buffer size
+            if @data.getbyte(pointer+8-1) == nil
+              debug [:buffer_incomplete, @data]
+              error = true
+              next
+            end
+
+            # Only using the last 4 bytes for now, till I work out how to
+            # unpack 8 bytes. I'm sure 4GB frames will do for now :)
+            l = @data.getbytes(pointer+4, 4).unpack('N').first
+            pointer += 8
+            l
+          when 126 # Length defined by 2 bytes
+            # Check buffer size
+            if @data.getbyte(pointer+2-1) == nil
+              debug [:buffer_incomplete, @data]
+              error = true
+              next
+            end
+
+            l = @data.getbytes(pointer, 2).unpack('n').first
+            pointer += 2
+            l
+          else
+            length
+          end
+
+          # Check buffer size
+          if @data.getbyte(pointer+payload_length-1) == nil
+            debug [:buffer_incomplete, @data]
+            error = true
+            next
+          end
+
+          # Read application data
+          application_data = @data.getbytes(pointer, payload_length)
+          pointer += payload_length
+
+          # Throw away data up to pointer
+          @data.slice!(0...(pointer + 4))
+
+          frame_type = opcode_to_type(opcode)
+
+          if frame_type == :continuation && !@frame_type
+            raise WebSocketError, 'Continuation frame not expected'
+          end
+
+          if !fin
+            debug [:moreframe, frame_type, application_data]
+            @application_data_buffer << application_data
+            @frame_type = frame_type
+          else
+            # Message is complete
+            if frame_type == :continuation
+              @application_data_buffer << application_data
+              message(@frame_type, '', @application_data_buffer)
+              @application_data_buffer = ''
+              @frame_type = nil
+            else
+              message(frame_type, '', application_data)
+            end
+          end
+        end # end while
+      end
+
+      def send_frame(frame_type, application_data)
+        debug [:sending_frame, frame_type, application_data]
+
+        if @state == :closing && data_frame?(frame_type)
+          raise WebSocketError, "Cannot send data frame since connection is closing"
+        end
+
+        frame = ''
+
+        opcode = type_to_opcode(frame_type)
+        byte1 = opcode | 0b10000000 # fin bit set, rsv1-3 are 0
+        frame << byte1
+
+        length = application_data.size
+        if length <= 125
+          byte2 = length # since rsv4 is 0
+          frame << byte2
+        elsif length < 65536 # write 2 byte length
+          frame << 126
+          frame << [length].pack('n')
+        else # write 8 byte length
+          frame << 127
+          frame << [length >> 32, length & 0xFFFFFFFF].pack("NN")
+        end
+
+        frame << application_data
+
+        @connection.send_data(frame)
+      end
+
+      def send_text_frame(data)
+        send_frame(:text, data)
+      end
+
+      private
+
+      FRAME_TYPES = {
+        :continuation => 0,
+        :text => 1,
+        :binary => 2,
+        # 3-7 reserved for further non-control frames
+        :close => 8,
+        :ping => 9,
+        :pong => 10,
+        # 11-15 reserved for further control frames
+      }
+      FRAME_TYPES_INVERSE = FRAME_TYPES.invert
+      # Frames are either data frames or control frames
+      DATA_FRAMES = [:text, :binary, :continuation]
+
+      def type_to_opcode(frame_type)
+        FRAME_TYPES[frame_type] || raise("Unknown frame type")
+      end
+
+      def opcode_to_type(opcode)
+        FRAME_TYPES_INVERSE[opcode] || raise("Unknown opcode")
+      end
+
+      def data_frame?(type)
+        DATA_FRAMES.include?(type)
+      end
+    end
+  end
+end

--- a/lib/em-websocket/handler08.rb
+++ b/lib/em-websocket/handler08.rb
@@ -1,0 +1,10 @@
+module EventMachine
+  module WebSocket
+    class Handler08 < Handler
+      include Handshake04
+      include Framing08
+      include MessageProcessor06
+      include Close06
+    end
+  end
+end

--- a/lib/em-websocket/handler_factory.rb
+++ b/lib/em-websocket/handler_factory.rb
@@ -87,6 +87,8 @@ module EventMachine
           Handler05.new(connection, request, debug)
         when 6
           Handler06.new(connection, request, debug)
+        when 8
+          Handler08.new(connection, request, debug)
         else
           # According to spec should abort the connection
           raise WebSocketError, "Protocol version #{version} not supported"


### PR DESCRIPTION
Chrome Dev Channel and Firefox Aurora recently rolled over to version 8 of the WebSocket protocol, which changed framing opcodes around so that they're not backwards compatible.  I didn't explicitly handle version 06 in handler_factory.rb, but Handler08 should be backwards compatible with version 7 if you wish to use it.  I'm assuming since version 4 was skipped, skipping is occasionally OK, but I leave it up to you guys whether version 7 should be handled.
