### PR TITLE
MaskedString#getbytes may return the utf8 encoded string

### DIFF
--- a/em-websocket.gemspec
+++ b/em-websocket.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency("eventmachine", ">= 0.12.9")
   s.add_dependency("addressable", '>= 2.1.1')
-  s.add_development_dependency('em-spec', '~> 0.2.5')
+  s.add_development_dependency('em-spec', '~> 0.2.6')
   s.add_development_dependency("eventmachine", "~> 0.12.10")
   s.add_development_dependency('em-http-request', '~> 0.2.6')
-  s.add_development_dependency('rspec', "~> 2.6.0")
+  s.add_development_dependency('rspec', "~> 2.8.0")
   s.add_development_dependency('rake')
 end

--- a/lib/em-websocket/masking04.rb
+++ b/lib/em-websocket/masking04.rb
@@ -29,7 +29,7 @@ module EventMachine
       end
 
       def getbytes(start_index, count)
-        data = ''
+        data = ''.force_encoding('ASCII-8BIT')
         count.times do |i|
           data << getbyte(start_index + i)
         end

--- a/lib/em-websocket/version.rb
+++ b/lib/em-websocket/version.rb
@@ -1,5 +1,5 @@
 module EventMachine
   module Websocket
-    VERSION = "0.3.6"
+    VERSION = "0.3.7"
   end
 end


### PR DESCRIPTION
Force MaskedString#getbytes using encoding ASCII-8BIT, or else it will use the default encoding which may cause problem
