### PR TITLE
Raise HandshakeError on malformed requests (empty header)

### DIFF
--- a/lib/em-websocket/handler_factory.rb
+++ b/lib/em-websocket/handler_factory.rb
@@ -15,6 +15,8 @@ module EventMachine
 
         lines = header.split("\r\n")
 
+        raise HandshakeError, "Empty HTTP header" unless lines.size > 0
+
         # extract request path
         first_line = lines.shift.match(PATH)
         raise HandshakeError, "Invalid HTTP header" unless first_line


### PR DESCRIPTION
My em-websocket crashed in production, because someone sent an empty http header (request looks `"\r\n\r\nfoobar"`). This was the backtrace:

```
NoMethodError: undefined method `match' for nil:NilClass:
    /em-websocket-0.3.6/lib/em-websocket/handler_factory.rb:19:in `build'
    /em-websocket-0.3.6/lib/em-websocket/connection.rb:108:in `dispatch'
    /em-websocket-0.3.6/lib/em-websocket/connection.rb:71:in `receive_data'
    /eventmachine-0.12.10/lib/eventmachine.rb:256:in `run_machine'
    /eventmachine-0.12.10/lib/eventmachine.rb:256:in `run'
```

My patch fixes this.
