### PR TITLE
Allow Connection header to include other values in addition to "Upgrade"...

### DIFF
--- a/lib/em-websocket/handler_factory.rb
+++ b/lib/em-websocket/handler_factory.rb
@@ -69,7 +69,7 @@ module EventMachine
         end
 
         # Validate that Connection and Upgrade headers
-        unless request['connection'] && request['connection'] =~ /Upgrade/ && request['upgrade'] && request['upgrade'].downcase == 'websocket'
+        unless request['connection'] && request['connection'].to_s =~ /Upgrade/ && request['upgrade'] && request['upgrade'].downcase == 'websocket'
           raise HandshakeError, "Connection and Upgrade headers required"
         end
 


### PR DESCRIPTION
....

In production with HAProxy, I have been using the option http-pretend-keepalive to eliminate the addition of "close" to "Connection: ". This commit would make that unnecessary.
