### PR TITLE
Added secure_proxy option for when em-websocket is behind an ssl terminator

### DIFF
--- a/lib/em-websocket/connection.rb
+++ b/lib/em-websocket/connection.rb
@@ -108,7 +108,7 @@ module EventMachine
         else
           debug [:inbound_headers, data]
           @data << data
-          @handler = HandlerFactory.build(self, @data, @secure, @secure_proxy, @debug)
+          @handler = HandlerFactory.build(self, @data, @secure || @secure_proxy, @debug)
           unless @handler
             # The whole header has not been received yet.
             return false

--- a/lib/em-websocket/handler_factory.rb
+++ b/lib/em-websocket/handler_factory.rb
@@ -4,7 +4,7 @@ module EventMachine
       PATH   = /^(\w+) (\/[^\s]*) HTTP\/1\.1$/
       HEADER = /^([^:]+):\s*(.+)$/
 
-      def self.build(connection, data, secure = false, secure_proxy = false, debug = false)
+      def self.build(connection, data, secure = false, debug = false)
         (header, remains) = data.split("\r\n\r\n", 2)
         unless remains
           # The whole header has not been received yet.
@@ -35,10 +35,10 @@ module EventMachine
           request[h[1].strip.downcase] = h[2].strip if h
         end
 
-        build_with_request(connection, request, remains, secure, secure_proxy, debug)
+        build_with_request(connection, request, remains, secure, debug)
       end
 
-      def self.build_with_request(connection, request, remains, secure = false, secure_proxy = false, debug = false)
+      def self.build_with_request(connection, request, remains, secure = false, debug = false)
         # Determine version heuristically
         version = if request['sec-websocket-version']
           # Used from drafts 04 onwards
@@ -74,7 +74,7 @@ module EventMachine
         end
 
         # transform headers
-        protocol = ((secure || secure_proxy) ? "wss" : "ws")
+        protocol = (secure ? "wss" : "ws")
         request['host'] = Addressable::URI.parse("#{protocol}://"+request['host'])
 
         case version


### PR DESCRIPTION
Added secure_proxy option for when em-websocket is behind an ssl terminator like stunnel, so that it will send upgrade responses with the wss:// scheme, rather than the ws:// scheme.
