### PR TITLE
Features/explicit path query

### DIFF
--- a/lib/em-websocket/handler_factory.rb
+++ b/lib/em-websocket/handler_factory.rb
@@ -28,7 +28,11 @@ module EventMachine
         end
 
         # extract query string values
-        request['query'] = Addressable::URI.parse(request['path']).query_values ||= {}
+        Addressable::URI.parse(request['path']).tap do |uri|
+          request['query'] = uri.query_values || {}
+          request['path'] = uri.path || '/'
+        end
+
         # extract remaining headers
         lines.each do |line|
           h = HEADER.match(line)

--- a/spec/integration/common_spec.rb
+++ b/spec/integration/common_spec.rb
@@ -61,9 +61,10 @@ describe "WebSocket server" do
 
       EventMachine::WebSocket.start(:host => "0.0.0.0", :port => 12345) do |ws|
         ws.onopen {
-          path, query = ws.request["path"].split('?')
+          path = ws.request['path']
+          query = ws.request['query']
           path.should == '/'
-          Hash[*query.split(/&|=/)].should == {"foo"=>"bar", "baz"=>"qux"}
+          query.should == {"foo"=>"bar", "baz"=>"qux"}
           ws.request["query"]["foo"].should == "bar"
           ws.request["query"]["baz"].should == "qux"
         }


### PR DESCRIPTION
This makes `ws.request['path']` return just the path and `ws.request['query']` the parsed query hash.

Unfortunately, this breaks the existing API. Not sure if you're prepared to do a release to bring this in, or whether you want a knob to opt into this behaviour.
