### PR TITLE
initial work on onhandshake event (useful for authorization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ require 'em-websocket'
 
 def authorized?
     # implement something here
-    403
+    false
 end
 
 EM.run {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@ EventMachine based, async, Ruby WebSocket server. Take a look at examples direct
 
 * [Ruby & Websockets: TCP for the Web](http://www.igvita.com/2009/12/22/ruby-websockets-tcp-for-the-browser/)
 
+## NOTES ON FORK
+
+This fork of the original code adds an onhandshake event, which can be used to
+return HTTP error codes (e.g., 403, 404, etc) before the HTTP response is
+upgraded to a websocket.
+
+See examples/onhandshake_auth.rb for a more-detailed example.
+
+```ruby
+require 'em-websocket'
+
+def authorized?
+    # implement something here
+    403
+end
+
+EM.run {
+  EM::WebSocket.run(:host => "0.0.0.0", :port => 8080) do |ws|
+    ws.onhandshake { |handshake|
+        403 unless authorized?
+    }
+    # rest of implementation
+  end
+}
+```
+
 ## Simple server example
 
 ```ruby

--- a/examples/onhandshake_auth.rb
+++ b/examples/onhandshake_auth.rb
@@ -1,0 +1,50 @@
+require File.expand_path('../../lib/em-websocket', __FILE__)
+
+EM.run do
+  EventMachine::WebSocket.start(:host => "0.0.0.0", :port => 8282, :debug => true) do |ws|
+
+    #
+    #   Do authentication/authorization in onhandshake. We can return HTTP status codes
+    #   to indicate failure
+    #
+    ws.onhandshake {|handshake|
+      puts "handshake path: #{handshake.path}"
+      
+      # If the return code is true or 101 (web socket upgrade success),
+      # continue with the websocket upgrade response to upgrade the HTTP
+      # connection to a websocket (ws.onopen will then be invoked)
+      ret = true  
+      ret = 101
+
+      # We can inspect the handshake .path, .query, or .headers to do our auth
+      # For example, we may want to verify that the client passes some long,
+      # predetermined session key, validate it in our persistent session store,
+      # and deny access if it is invalid. This contrived example inspects the
+      # path
+      if handshake.path == '/forbidden'
+        ret = 403
+      end
+
+      # raise HttpStatusForbidden (indicates HTTP 403) or another subclass of
+      # HandshakeError to deny access. Returning a numeric status code is syntactic
+      # sugar for calling:
+      #
+      #       raise HttpErrorStatus.new(http_error_code)
+      #
+      if handshake.query['authorized'] == 'false'
+        raise EventMachine::WebSocket::HttpStatusForbidden
+      end
+
+      ret 
+    }
+
+    ws.onopen {|handshake|
+      ws.send "Auth succeeded. You are connected to a websocket."
+    }
+
+    ws.onclose {
+    }
+    
+  end
+end
+

--- a/lib/em-websocket/connection.rb
+++ b/lib/em-websocket/connection.rb
@@ -1,3 +1,7 @@
+# Use Rack::Utils for HTTP error status codes. We could also just implement
+# a subset of that functionality here to remove the dependency
+require 'rack'
+
 module EventMachine
   module WebSocket
     class Connection < EventMachine::Connection
@@ -6,6 +10,7 @@ module EventMachine
       attr_writer :max_frame_size
 
       # define WebSocket callbacks
+      def onhandshake(&blk); @onhandshake = blk; end
       def onopen(&blk);     @onopen = blk;    end
       def onclose(&blk);    @onclose = blk;   end
       def onerror(&blk);    @onerror = blk;   end
@@ -102,7 +107,7 @@ module EventMachine
           send_flash_cross_domain_file
         else
           @handshake ||= begin
-            handshake = Handshake.new(@secure || @secure_proxy)
+            handshake = Handshake.new(@secure || @secure_proxy, @onhandshake)
 
             handshake.callback { |upgrade_response, handler_klass|
               debug [:accepting_ws_version, handshake.protocol_version]
@@ -116,7 +121,20 @@ module EventMachine
             handshake.errback { |e|
               debug [:error, e]
               trigger_on_error(e)
-              # Handshake errors require the connection to be aborted
+              @handshake = nil
+              if e.respond_to?(:code)
+                http_status_code = e.code
+                message = Rack::Utils::HTTP_STATUS_CODES[http_status_code]
+                #body = message+"\n"
+                payload = sprintf("HTTP/1.1 %d %s\r\n", http_status_code, message) +
+                  "Content-Type: text/plain\r\n\r\n" + message
+                self.send_data(payload)
+                # TODO: handle 30x redirects and 401. We do not need to do anything special
+                # for 403, 404. Do we need any special processing for other 40x codes?
+                # get HTTP status messages for codes. The only error code that we would
+                # use would probably be 403 (?) Maybe 404.
+                # Uncategorized handshake errors require the connection to be aborted
+              end
               abort
             }
 

--- a/lib/em-websocket/websocket.rb
+++ b/lib/em-websocket/websocket.rb
@@ -11,6 +11,18 @@ module EventMachine
     # Used for errors that occur during WebSocket handshake
     class HandshakeError < WebSocketError; end
 
+    class HttpStatusForbidden < HandshakeError
+        def code; 403; end
+    end
+
+    class HttpErrorStatus < HandshakeError
+      attr_reader :code
+      def initialize(code, message=nil)
+        super(message)
+        @code = code
+      end
+    end
+
     # Used for errors which should cause the connection to close.
     # See RFC6455 §7.4.1 for a full description of meanings
     class WSProtocolError < WebSocketError


### PR DESCRIPTION
I don't think this is ready to pull as-is. Martyn mentioned that the rack dependency adds too much overhead. I agree that having it is probably unnecessary. If you want to allow users to send HTTP error codes in the handshake, the first step would be to identify which ones should be supported (403, 404, ... maybe LATER support 30x for redirects, but while supporting redirects would add polish, I personally don't think they are necessary).

Right now my API additions support either throwing exceptions or returning numeric HTTP error codes in onhandshake (syntactic sugar) that then get wrapped in an exception. Supporting a finite set of exceptions w/o supporting numeric error codes would simplify the code and would not require implementation of ALL possible HTTP errors (only the handful of useful ones). Users could also subclass HandshakeError with an exception that would support a compatible API (implement code() and an http_status_message() or something like that) so they could implement others as-needed. We could provide an example of a generic extension of HandshakeError that could use Rack to translate codes-to-messages and thereby support many more codes without having to add this exception class (and the rack dependency) to em-websocket itself.

Anyway, I'm open to suggestions for possible improvements to the API that should happen prior to pull.
