### PR TITLE
get remote-host's IP Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ require 'em-websocket'
 
 EM.run {
   EM::WebSocket.run(:host => "0.0.0.0", :port => 8080) do |ws|
-    ws.onopen { |handshake|
-      puts "WebSocket connection open"
+    ws.onopen { |handshake, connection|
+      puts "WebSocket connection open from #{connection.remote_addr}"
 
       # Access properties on the EM::WebSocket::Handshake object, e.g.
       # path, query_string, origin, headers

--- a/examples/echo.rb
+++ b/examples/echo.rb
@@ -2,12 +2,13 @@ require File.expand_path('../../lib/em-websocket', __FILE__)
 
 EM.run {
   EM::WebSocket.run(:host => "0.0.0.0", :port => 8080, :debug => false) do |ws|
-    ws.onopen { |handshake|
+    ws.onopen { |handshake, connection|
       puts "WebSocket opened #{{
         :path => handshake.path,
         :query => handshake.query,
         :origin => handshake.origin,
       }}"
+      puts "from #{connection.remote_addr}"
 
       ws.send "Hello Client!"
     }

--- a/lib/em-websocket/connection.rb
+++ b/lib/em-websocket/connection.rb
@@ -17,7 +17,7 @@ module EventMachine
         @onmessage.call(msg) if defined? @onmessage
       end
       def trigger_on_open(handshake)
-        @onopen.call(handshake) if defined? @onopen
+        @onopen.call(handshake, self) if defined? @onopen
       end
       def trigger_on_close(event = {})
         @onclose.call(event) if defined? @onclose
@@ -95,6 +95,10 @@ module EventMachine
         debug [:error, e]
         # These are application errors - raise unless onerror defined
         trigger_on_error(e) || raise(e)
+      end
+
+      def remote_addr
+        get_peername[2,6].unpack('nC4')[1..4].join('.')
       end
 
       def dispatch(data)

--- a/spec/integration/common_spec.rb
+++ b/spec/integration/common_spec.rb
@@ -37,7 +37,7 @@ describe "WebSocket server" do
       end
 
       start_server do |ws|
-        ws.onopen { |handshake|
+        ws.onopen { |handshake, connection|
           headers = handshake.headers
           headers["User-Agent"].should == "EventMachine HttpClient"
           headers["Connection"].should == "Upgrade"
@@ -71,11 +71,12 @@ describe "WebSocket server" do
       end
 
       start_server do |ws|
-        ws.onopen { |handshake|
+        ws.onopen { |handshake, connection|
           handshake.path.should == '/hello'
           handshake.query_string.split('&').sort.
             should == ["baz=qux", "foo=bar"]
           handshake.query.should == {"foo"=>"bar", "baz"=>"qux"}
+          connection.remote_addr.should match /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
         }
         ws.onclose {
           ws.state.should == :closed
@@ -114,7 +115,7 @@ describe "WebSocket server" do
       end
 
       start_server do |ws|
-        ws.onopen { |handshake|
+        ws.onopen { |handshake, connection|
           handshake.headers["User-Agent"].should == "EventMachine HttpClient"
         }
         ws.onclose {

--- a/spec/integration/shared_examples.rb
+++ b/spec/integration/shared_examples.rb
@@ -6,7 +6,7 @@ shared_examples_for "a websocket server" do
   it "should expose the protocol version" do
     em {
       start_server { |ws|
-        ws.onopen { |handshake|
+        ws.onopen { |handshake, connection|
           handshake.protocol_version.should == version
           done
         }
@@ -19,7 +19,7 @@ shared_examples_for "a websocket server" do
   it "should expose the origin header" do
     em {
       start_server { |ws|
-        ws.onopen { |handshake|
+        ws.onopen { |handshake, connection|
           handshake.origin.should == 'http://example.com'
           done
         }


### PR DESCRIPTION
I've made a pull-request for issue #103. It includes update for README and specs.
## Usage

``` ruby
EM::run do

  EM::WebSocket.start(:host => "0.0.0.0", :port => PORT) do |ws|
    ws.onopen{|handshake, connection|
      puts "connect from #{connection.remote_addr}"  ## => "127.0.0.1"
    end
  end

end
```

I'm wondering if you like this.
