### PR TITLE
fix #102.  Change version restrictions on http_parser.rb to >= instead of ~>.  

### DIFF
--- a/em-websocket.gemspec
+++ b/em-websocket.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("eventmachine", ">= 0.12.9")
-  s.add_dependency("http_parser.rb", '~> 0.5.3')
+  s.add_dependency("http_parser.rb", '>= 0.5.3')
   s.add_development_dependency('em-spec', '~> 0.2.6')
   s.add_development_dependency("eventmachine")
   s.add_development_dependency('em-http-request', '~> 0.2.6')


### PR DESCRIPTION
http_parser.rb does not work on Ruby 2.0 with Windows.  Changing this to a >= instead of ~> allows http_parser.rb to be upgraded to 0.6.0.beta.2 which does work on windows.
