### PR TITLE
Update http_parser.rb dep to 0.6.0.pre2

### DIFF
--- a/em-websocket.gemspec
+++ b/em-websocket.gemspec
@@ -20,10 +20,12 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("eventmachine", ">= 0.12.9")
-  s.add_dependency("http_parser.rb", '~> 0.5.3')
+  s.add_dependency("http_parser.rb", '~> 0.6.0.beta.2')
   s.add_development_dependency('em-spec', '~> 0.2.6')
   s.add_development_dependency("eventmachine")
-  s.add_development_dependency('em-http-request', '~> 0.2.6')
+  s.add_development_dependency('em-http-request', '~> 1.1.1')
+  s.add_development_dependency('em-websocket')
+  s.add_development_dependency('em-websocket-client', '>= 0.1.2')
   s.add_development_dependency('rspec', "~> 2.12.0")
   s.add_development_dependency('rake')
 end

--- a/lib/em-websocket/handshake.rb
+++ b/lib/em-websocket/handshake.rb
@@ -48,12 +48,12 @@ module EventMachine
       # Returns the request path (excluding any query params)
       #
       def path
-        @parser.request_path
+        URI.parse(@parser.request_url).path
       end
 
       # Returns the query params as a string foo=bar&baz=...
       def query_string
-        @parser.query_string
+        URI.parse(@parser.request_url).query.to_s
       end
 
       def query

--- a/spec/integration/draft76_spec.rb
+++ b/spec/integration/draft76_spec.rb
@@ -178,7 +178,7 @@ describe "WebSocket server draft76" do
       start_server { |server|
         server.onerror { |error|
           error.should be_an_instance_of EM::WebSocket::HandshakeError
-          error.message.should == "Invalid HTTP header: Could not parse data entirely"
+          error.message.should == "Invalid HTTP header: Could not parse data entirely (1 != 29)"
           done
         }
       }

--- a/spec/unit/handshake_spec.rb
+++ b/spec/unit/handshake_spec.rb
@@ -155,7 +155,7 @@ describe EM::WebSocket::Handshake do
     handshake.receive_data("\r\n\r\nfoobar")
     
     handshake.
-      should fail_with_error(EM::WebSocket::HandshakeError, 'Invalid HTTP header: Could not parse data entirely')
+      should fail_with_error(EM::WebSocket::HandshakeError, 'Invalid HTTP header: Could not parse data entirely (4 != 10)')
   end
 
   # This might seems crazy, but very occasionally we saw multiple "Upgrade:


### PR DESCRIPTION
em-http-request needs to be updated to 1.1.1 for dependency compatibility

em-websocket-client added to spec suite since em-http-request 1.x does not support websockets

Only functional change outside of this was to manually parse the request_path and query_string as those are no longer exposed by the http_parser C library. This could be reworked a bit to store the URI instance or other if this functionality is still needed.

https://github.com/joyent/http-parser/pull/54

If anything else needs to be done to clean this up to be able to make it in just shout out.

Thanks.
