### PR TITLE
update http_parser dependency to 0.6.0

### DIFF
--- a/em-websocket.gemspec
+++ b/em-websocket.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("eventmachine", ">= 0.12.9")
-  s.add_dependency("http_parser.rb", '~> 0.6.0.beta.2')
+  s.add_dependency("http_parser.rb", '~> 0.6.0')
   s.add_development_dependency('em-spec', '~> 0.2.6')
   s.add_development_dependency("eventmachine")
   s.add_development_dependency('em-http-request', '~> 1.1.1')


### PR DESCRIPTION
This updates the dependency on http_parser.rb to the recently released 0.6.0. I've had reports of issues due to dependency [conflicts](https://github.com/tweetstream/tweetstream/issues/152)
