### PR TITLE
remove dev_dependency on self

### DIFF
--- a/em-websocket.gemspec
+++ b/em-websocket.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('em-spec', '~> 0.2.6')
   s.add_development_dependency("eventmachine")
   s.add_development_dependency('em-http-request', '~> 1.1.1')
-  s.add_development_dependency('em-websocket')
   s.add_development_dependency('em-websocket-client', '>= 0.1.2')
   s.add_development_dependency('rspec', "~> 2.12.0")
   s.add_development_dependency('rake')


### PR DESCRIPTION
Performing a `bundle install` resulted in the following warning: 

> Your Gemfile lists the gem em-websocket (>= 0) more than once.
> You should probably keep only one of them.
> While it's not a problem now, it could cause errors if you change the version of just one of them later.

I found it odd that the gemspec has a dev dependency on itself.  Removing the dev dependency removed the above message.
