### PR TITLE
Remove duplicated dependency in gemspec file

### DIFF
--- a/em-websocket.gemspec
+++ b/em-websocket.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency("eventmachine", ">= 0.12.9")
   s.add_dependency("http_parser.rb", '~> 0.6.0')
   s.add_development_dependency('em-spec', '~> 0.2.6')
-  s.add_development_dependency("eventmachine")
   s.add_development_dependency('em-http-request', '~> 1.1.1')
   s.add_development_dependency('em-websocket-client', '>= 0.1.2')
   s.add_development_dependency('rspec', "~> 2.12.0")


### PR DESCRIPTION
I got this error when running `bundle update`

```
Using http_parser.rb (0.6.0)

em-websocket at /home/davidr/.rvm/gems/ruby-2.1.0/bundler/gems/em-websocket-bd716eda8b2d did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  duplicate dependency on eventmachine (>= 0, development), (>= 0.12.9) use:
    add_runtime_dependency 'eventmachine', '>= 0', '>= 0.12.9'

Using em-websocket (0.5.0) from git://github.com/igrigorik/em-websocket.git (at master)
```

This fixes it.
