### PR TITLE
Outbound limit

### DIFF
--- a/lib/em-websocket/connection.rb
+++ b/lib/em-websocket/connection.rb
@@ -45,6 +45,7 @@ module EventMachine
         @secure_proxy = options[:secure_proxy] || false
         @tls_options = options[:tls_options] || {}
         @close_timeout = options[:close_timeout]
+        @outbound_limit = options[:outbound_limit] || 0
 
         @handler = nil
 
@@ -86,6 +87,16 @@ module EventMachine
 
         # These are application errors - raise unless onerror defined
         trigger_on_error(e) || raise(e)
+      end
+
+      def send_data(data)
+        if @outbound_limit > 0 &&
+            get_outbound_data_size + data.bytesize > @outbound_limit
+          abort(:outbound_limit_reached)
+          return 0
+        end
+
+        super(data)
       end
 
       def unbind

--- a/spec/integration/common_spec.rb
+++ b/spec/integration/common_spec.rb
@@ -108,4 +108,31 @@ describe "WebSocket server" do
       end
     }
   end
+
+  context "outbound limit set" do
+    it "should close the connection if the limit is reached" do
+      em {
+        start_server(:outbound_limit => 150) do |ws|
+          # Increase the message size by one on each loop
+          ws.onmessage{|msg| ws.send(msg + "x") }
+          ws.onclose{|status|
+            status[:code].should == 1006 # Unclean
+            status[:was_clean].should be_false
+          }
+        end
+
+        EM.add_timer(0.1) do
+          ws = EventMachine::WebSocketClient.connect('ws://127.0.0.1:12345/')
+          ws.callback { ws.send_msg "hello" }
+          ws.disconnect { done } # Server closed the connection
+          ws.stream { |msg|
+            # minus frame size ? (getting 146 max here)
+            msg.data.size.should <= 150
+            # Return back the message
+            ws.send_msg(msg.data)
+          }
+        end
+      }
+    end
+  end
 end


### PR DESCRIPTION
Allows to limit the size of buffered data (in EM). It's useful when slow clients can't keep up with the traffic and stack up too much data.

I don't really like that EM keeps it's own separate buffer when the TCP stack already has one but then EM would also be supporting a push-back mechanism when the buffer is full. In any case this is a compromise, disconnect the client when too much data has piled up.
