### PR TITLE
Fix broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If unsure use a code in the 4xxx range. em-websocket may also close a connection
 
 ## Secure server
 
-It is possible to accept secure `wss://` connections by passing `:secure => true` when opening the connection. Pass a `:tls_options` hash containing keys as described in http://eventmachine.rubyforge.org/EventMachine/Connection.html#start_tls-instance_method
+It is possible to accept secure `wss://` connections by passing `:secure => true` when opening the connection. Pass a `:tls_options` hash containing keys as described in http://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Connection:start_tls
 
 **Warning**: Safari 5 does not currently support prompting on untrusted SSL certificates therefore using a self signed certificate may leave you scratching your head.
 


### PR DESCRIPTION
Hi, I was reading the README and found a RubyForge link. Since it doesn't exist anymore, I changed the link to point to rubydoc.info instead.