### PR TITLE
Add license to gemspec

### DIFF
--- a/em-websocket.gemspec
+++ b/em-websocket.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://github.com/igrigorik/em-websocket"
   s.summary     = %q{EventMachine based WebSocket server}
   s.description = %q{EventMachine based WebSocket server}
+  s.license     = 'MIT'
 
   s.rubyforge_project = "em-websocket"
 


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.