### PR TITLE
Update rspec version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 gem "em-websocket-client", git: "git@github.com:movitto/em-websocket-client.git", branch: "expose-websocket-api"
 gem "em-spec", "~> 0.2.6"
 gem "em-http-request", "~> 1.1.1"
-gem "rspec", "~> 2.12.0"
+gem "rspec", "~> 3.5.0"
 gem "rake"

--- a/spec/integration/common_spec.rb
+++ b/spec/integration/common_spec.rb
@@ -117,7 +117,7 @@ describe "WebSocket server" do
           ws.onmessage{|msg| ws.send(msg + "x") }
           ws.onclose{|status|
             status[:code].should == 1006 # Unclean
-            status[:was_clean].should be_false
+            status[:was_clean].should be false
           }
         end
 


### PR DESCRIPTION
Hi, I noticed that`$ bundle install` is no longer working because a Rake method that is being called by rspec-core was renamed from `last_comment` to `last_method`. 

The pinned version of rpsec, 2.12.0 continues to call `Rake.application.last_comment`, which was renamed to `Rake.application.last_description`, in the version of Rake that we're pulling.

See: https://github.com/rspec/rspec-core/commit/8e723fc805e901ac4fa5483837138b175d411d6e for the commit that introduces the change, which was part of rspec 3.5.0.

```
Jasons-MacBook-Pro-3:em-websocket atlas$ rake
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x007fef231601d8>
/Users/atlas/.rvm/gems/ruby-2.4.0/gems/rspec-core-2.12.2/lib/rspec/core/rake_task.rb:119:in `initialize'
/Users/atlas/Repos/em-websocket/Rakefile:6:in `new'
/Users/atlas/Repos/em-websocket/Rakefile:6:in `<top (required)>'
/Users/atlas/.rvm/gems/ruby-2.4.0/gems/rake-12.3.0/exe/rake:27:in `<top (required)>'
/Users/atlas/.rvm/gems/ruby-2.4.0/bin/ruby_executable_hooks:15:in `eval'
/Users/atlas/.rvm/gems/ruby-2.4.0/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```

After pinning rspec to 3.5.0 there was also one test error when running rake:
```
Failures:

  1) WebSocket server outbound limit set should close the connection if the limit is reached
     Failure/Error: status[:was_clean].should be_false
       expected false to respond to `false?` or perhaps you meant `be false` or `be_falsey`
     # ./spec/integration/common_spec.rb:120:in `block (6 levels) in <top (required)>'
     # ./lib/em-websocket/connection.rb:27:in `call'
     # ./lib/em-websocket/connection.rb:27:in `trigger_on_close'
     # ./lib/em-websocket/handler.rb:83:in `unbind'
     # ./lib/em-websocket/connection.rb:105:in `unbind'
     # /Users/atlas/.rvm/gems/ruby-2.2.4/gems/eventmachine-1.2.5/lib/eventmachine.rb:1483:in `event_callback'
     # /Users/atlas/.rvm/gems/ruby-2.2.4/gems/eventmachine-1.2.5/lib/eventmachine.rb:194:in `run_machine'
     # /Users/atlas/.rvm/gems/ruby-2.2.4/gems/eventmachine-1.2.5/lib/eventmachine.rb:194:in `run'
     # /Users/atlas/.rvm/gems/ruby-2.2.4/gems/em-spec-0.2.7/lib/em-spec/rspec.rb:26:in `em'
     # ./spec/integration/common_spec.rb:114:in `block (3 levels) in <top (required)>'
```

The tweak in the PR fixes it. I tested this on ruby 2.2 and 2.4