### PR TITLE
Allow newer versions of http_parser

### DIFF
--- a/em-websocket.gemspec
+++ b/em-websocket.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("eventmachine", ">= 0.12.9")
-  s.add_dependency("http_parser.rb", '>= 0.6.1')
+  s.add_dependency("http_parser.rb", '~> 0')
 end

--- a/em-websocket.gemspec
+++ b/em-websocket.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency("eventmachine", ">= 0.12.9")
-  s.add_dependency("http_parser.rb", '~> 0.6.0')
+  s.add_dependency("http_parser.rb", '>= 0.6.1')
 end


### PR DESCRIPTION
Allows versions of http_parser later than 0.6.0. Tests ran successfully after this change.

This PR addresses the following issues:

- https://github.com/igrigorik/em-websocket/issues/157
- https://github.com/igrigorik/em-websocket/issues/158