### PR TITLE
Add base64 as a runtime dependency to fix the LoadError in Ruby 3.4

### DIFF
--- a/em-websocket.gemspec
+++ b/em-websocket.gemspec
@@ -12,12 +12,14 @@ Gem::Specification.new do |s|
   s.summary     = %q{EventMachine based WebSocket server}
   s.description = %q{EventMachine based WebSocket server}
   s.license     = 'MIT'
+  s.required_ruby_version = ">= 2.4.0"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency("base64")
   s.add_dependency("eventmachine", ">= 0.12.9")
   s.add_dependency("http_parser.rb", '~> 0')
 end


### PR DESCRIPTION
This pull request has been created to address the `LoadError` for the `base64` gem in Ruby 3.4.

This error occurs because `base64` is no longer included in the default gems starting from Ruby 3.4.
https://bugs.ruby-lang.org/issues/19351

The error message is following:
```
irb(main):001> require 'em-websocket'
/my-app/tmp/ruby/3.4.0+0/gems/em-websocket-0.5.3/lib/em-websocket.rb:14: warning: base64 was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to silence this warning.
/Users/taketo/.rbenv/versions/3.4-dev/lib/ruby/3.4.0+0/bundled_gems.rb:76:in 'Kernel.require': cannot load such file -- base64 (LoadError)
	from /Users/taketo/.rbenv/versions/3.4-dev/lib/ruby/3.4.0+0/bundled_gems.rb:76:in 'block (2 levels) in Kernel#replace_require'
	...
```
- ruby: 3.4-dev (ruby 3.4.0dev (2024-10-29T07:56:32Z master 21b3dfa03b) +PRISM [arm64-darwin23])
- em-websocket: 0.5.3


### Details

This Pull Request changes to add `base64` as a runtime dependency to fix the `LoadError` in Ruby 3.4. (Fix #160)

Additionally, the `required_ruby_version` has been added to the gemspec to restrict the Ruby version to 2.4.0 or higher.
This is to explicitly specify compatibility, as the `base64` gem is only available for Ruby 2.4 and above.
https://github.com/ruby/base64/blob/v0.2.0/base64.gemspec#L17
