### PR TITLE
Add GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ruby: ['3.3', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5', '2.4']
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+    - name: Run RSpec tests
+      run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 gem "em-websocket-client", git: "git@github.com:movitto/em-websocket-client.git", branch: "expose-websocket-api"
 gem "em-spec", "~> 0.2.6"
 gem "em-http-request", "~> 1.1.1"
-gem "rspec", "~> 3.5.0"
+gem "rspec"
 gem "rake"

--- a/spec/integration/common_spec.rb
+++ b/spec/integration/common_spec.rb
@@ -31,15 +31,15 @@ describe "WebSocket server" do
       start_server do |ws|
         ws.onopen { |handshake|
           headers = handshake.headers
-          headers["Connection"].should == "Upgrade"
-          headers["Upgrade"].should == "websocket"
-          headers["Host"].to_s.should == "127.0.0.1:12345"
-          handshake.path.should == "/"
-          handshake.query.should == {}
-          handshake.origin.should == 'http://example.com'
+          expect(headers["Connection"]).to eq "Upgrade"
+          expect(headers["Upgrade"]).to eq "websocket"
+          expect(headers["Host"].to_s).to eq "127.0.0.1:12345"
+          expect(handshake.path).to eq "/"
+          expect(handshake.query).to eq({})
+          expect(handshake.origin).to eq 'http://example.com'
         }
         ws.onclose {
-          ws.state.should == :closed
+          expect(ws.state).to eq :closed
           done
         }
       end
@@ -59,13 +59,13 @@ describe "WebSocket server" do
 
       start_server do |ws|
         ws.onopen { |handshake|
-          handshake.path.should == '/hello'
-          handshake.query_string.split('&').sort.
-            should == ["baz=qux", "foo=bar"]
-          handshake.query.should == {"foo"=>"bar", "baz"=>"qux"}
+          expect(handshake.path).to eq '/hello'
+          expect(handshake.query_string.split('&').sort)
+            .to eq ["baz=qux", "foo=bar"]
+          expect(handshake.query).to eq({"foo"=>"bar", "baz"=>"qux"})
         }
         ws.onclose {
-          ws.state.should == :closed
+          expect(ws.state).to eq :closed
           done
         }
       end
@@ -77,9 +77,9 @@ describe "WebSocket server" do
       # 1. Start WebSocket server
       start_server { |ws|
         # 3. Try to send a message to the socket
-        lambda {
+        expect {
           ws.send('early message')
-        }.should raise_error('Cannot send data before onopen callback')
+        }.to raise_error('Cannot send data before onopen callback')
         done
       }
 
@@ -99,10 +99,10 @@ describe "WebSocket server" do
       start_server do |ws|
         ws.onopen { |handshake|
           headers = handshake.headers
-          headers["Host"].to_s.should == "127.0.0.1:12345"
+          expect(headers["Host"].to_s).to eq "127.0.0.1:12345"
         }
         ws.onclose {
-          ws.state.should == :closed
+          expect(ws.state).to eq :closed
           done
         }
       end
@@ -116,8 +116,8 @@ describe "WebSocket server" do
           # Increase the message size by one on each loop
           ws.onmessage{|msg| ws.send(msg + "x") }
           ws.onclose{|status|
-            status[:code].should == 1006 # Unclean
-            status[:was_clean].should be false
+            expect(status[:code]).to eq 1006 # Unclean
+            expect(status[:was_clean]).to be false
           }
         end
 
@@ -127,7 +127,7 @@ describe "WebSocket server" do
           ws.disconnect { done } # Server closed the connection
           ws.stream { |msg|
             # minus frame size ? (getting 146 max here)
-            msg.data.size.should <= 150
+            expect(msg.data.size).to be <= 150
             # Return back the message
             ws.send_msg(msg.data)
           }

--- a/spec/integration/draft03_spec.rb
+++ b/spec/integration/draft03_spec.rb
@@ -56,7 +56,7 @@ describe "draft03" do
       em {
         start_server { |ws|
           ws.onmessage { |msg|
-            msg.should == 'Hello'
+            expect(msg).to eq 'Hello'
             done
           }
         }
@@ -72,7 +72,7 @@ describe "draft03" do
       em {
         start_server { |ws|
           ws.onmessage { |msg|
-            msg.should == 'Hello'
+            expect(msg).to eq 'Hello'
             done
           }
         }
@@ -100,7 +100,7 @@ describe "draft03" do
         
         connection.onmessage { |frame|
           next if frame.nil?
-          frame.should == "\x03\x05Hello"
+          expect(frame).to eq "\x03\x05Hello"
           done
         }
       }
@@ -112,8 +112,8 @@ describe "draft03" do
         
         start_server { |ws|
           ws.onbinary { |msg|
-            msg.encoding.should == Encoding.find("BINARY") if defined?(Encoding)
-            msg.should == data
+            expect(msg.encoding).to eq Encoding.find("BINARY") if defined?(Encoding)
+            expect(msg).to eq data
             done
           }
         }
@@ -133,8 +133,8 @@ describe "draft03" do
         
         start_server { |ws|
           ws.onbinary { |msg|
-            msg.encoding.should == Encoding.find("BINARY") if defined?(Encoding)
-            msg.should == data
+            expect(msg.encoding).to eq Encoding.find("BINARY") if defined?(Encoding)
+            expect(msg).to eq data
             done
           }
         }
@@ -163,7 +163,7 @@ describe "draft03" do
 
         # Check that close ack received
         connection.onmessage { |frame|
-          frame.should == "\x01\x00"
+          expect(frame).to eq "\x01\x00"
           done
         }
       }
@@ -183,11 +183,11 @@ describe "draft03" do
 
           # 5. Onclose event on server
           ws.onclose { |event|
-            event.should == {
+            expect(event).to eq({
               :code => 1005,
               :reason => "",
               :was_clean => true,
-            }
+            })
             done
           }
         }
@@ -197,14 +197,14 @@ describe "draft03" do
 
         # 3. Check that close frame recieved and acknowlege it
         connection.onmessage { |frame|
-          frame.should == "\x01\x00"
+          expect(frame).to eq "\x01\x00"
           ack_received = true
           connection.send_data("\x01\x00")
         }
 
         # 4. Check that connection is closed _after_ the ack
         connection.onclose {
-          ack_received.should == true
+          expect(ack_received).to eq true
         }
       }
     end
@@ -215,11 +215,11 @@ describe "draft03" do
       em {
         start_server { |ws|
           ws.onclose { |event|
-            event.should == {
+            expect(event).to eq ({
               :code => 1005,
               :reason => "",
               :was_clean => true,
-            }
+            })
             done
           }
         }
@@ -242,9 +242,9 @@ describe "draft03" do
 
             # 3. Check that exception raised if I attempt to send more data
             EM.add_timer(0.1) {
-              lambda {
+              expect {
                 ws.send('hello world')
-              }.should raise_error(EM::WebSocket::WebSocketError, 'Cannot send data frame since connection is closing')
+              }.to raise_error(EM::WebSocket::WebSocketError, 'Cannot send data frame since connection is closing')
               done
             }
           }
@@ -276,7 +276,7 @@ describe "draft03" do
             connection.send_data("\x02\x05Hello")
           else
             # 4. Check that the pong is received
-            frame.should == "\x03\x05Hello"
+            expect(frame).to eq "\x03\x05Hello"
             done
           end
         }
@@ -287,7 +287,7 @@ describe "draft03" do
       em {
         start_server { |ws|
           ws.onopen {
-            ws.supports_close_codes?.should == false
+            expect(ws.supports_close_codes?).to eq false
             done
           }
         }

--- a/spec/integration/draft05_spec.rb
+++ b/spec/integration/draft05_spec.rb
@@ -40,7 +40,7 @@ describe "draft05" do
     em {
       start_server { |ws|
         ws.onopen {
-          ws.supports_close_codes?.should == false
+          expect(ws.supports_close_codes?).to eq false
           done
         }
       }

--- a/spec/integration/draft06_spec.rb
+++ b/spec/integration/draft06_spec.rb
@@ -50,14 +50,14 @@ describe "draft06" do
     em {
       start_server { |server|
         server.onopen {
-          server.instance_variable_get(:@handler).class.should == EventMachine::WebSocket::Handler06
+          expect(server.instance_variable_get(:@handler).class).to eq EventMachine::WebSocket::Handler06
         }
       }
       
       start_client { |client|
         client.onopen {
-          client.handshake_response.lines.sort.
-            should == format_response(@response).lines.sort
+          expect(client.handshake_response.lines.sort)
+            .to eq format_response(@response).lines.sort
           done
         }
       }
@@ -68,9 +68,9 @@ describe "draft06" do
     em {
       start_server { |server|
         server.onmessage { |msg|
-          msg.should == 'Hello'
+          expect(msg).to eq 'Hello'
           if msg.respond_to?(:encoding)
-            msg.encoding.should == Encoding.find("UTF-8")
+            expect(msg.encoding).to eq Encoding.find("UTF-8")
           end
           done
         }
@@ -92,11 +92,11 @@ describe "draft06" do
       start_server { |ws|
         ws.onclose { |event|
           # 2. Receive close event in server
-          event.should == {
+          expect(event).to eq({
             :code => 4004,
             :reason => "close reason",
             :was_clean => true,
-          }
+          })
           done
         }
       }
@@ -115,11 +115,11 @@ describe "draft06" do
     em {
       start_server { |ws|
         ws.onclose { |event|
-          event.should == {
+          expect(event).to eq({
             :code => 1005,
             :reason => "",
             :was_clean => true,
-          }
+          })
           done
         }
       }
@@ -135,7 +135,7 @@ describe "draft06" do
     em {
       start_server { |ws|
         ws.onopen {
-          ws.supports_close_codes?.should == true
+          expect(ws.supports_close_codes?).to eq true
           done
         }
       }

--- a/spec/integration/draft13_spec.rb
+++ b/spec/integration/draft13_spec.rb
@@ -55,8 +55,8 @@ describe "draft13" do
       connection = start_client
 
       connection.onopen {
-        connection.handshake_response.lines.sort.
-          should == format_response(@response).lines.sort
+        expect(connection.handshake_response.lines.sort)
+          .to eq format_response(@response).lines.sort
         done
       }
     }
@@ -67,14 +67,14 @@ describe "draft13" do
     em {
       start_server { |ws|
         ws.onopen {
-          ws.should be_pingable
+          expect(ws).to be_pingable
           EM.next_tick {
-            ws.ping('hello').should == true
+            expect(ws.ping('hello')).to eq true
           }
 
         }
         ws.onpong { |data|
-          data.should == 'hello'
+          expect(data).to eq 'hello'
           done
         }
       }
@@ -84,7 +84,7 @@ describe "draft13" do
       # Confusing, fake onmessage means any data after the handshake
       connection.onmessage { |data|
         # This is what a ping looks like
-        data.should == "\x89\x05hello"
+        expect(data).to eq "\x89\x05hello"
         # This is what a pong looks like
         connection.send_data("\x8a\x05hello")
       }
@@ -95,7 +95,7 @@ describe "draft13" do
     em {
       start_server { |ws|
         ws.onopen {
-          ws.supports_close_codes?.should == true
+          expect(ws.supports_close_codes?).to eq true
           done
         }
       }

--- a/spec/integration/draft75_spec.rb
+++ b/spec/integration/draft75_spec.rb
@@ -27,7 +27,7 @@ describe "WebSocket server draft75" do
         ws.callback { }
 
         ws.stream { |msg|
-          msg.data.should == MSG
+          expect(msg.data).to eq MSG
           EventMachine.stop
         }
       end
@@ -59,7 +59,7 @@ describe "WebSocket server draft75" do
         ws.onopen {}
         ws.onclose {}
         ws.onmessage {|msg|
-          msg.should == messages[received.size]
+          expect(msg).to eq messages[received.size]
           received.push msg
 
           EventMachine.stop if received.size == messages.size
@@ -82,7 +82,7 @@ describe "WebSocket server draft75" do
       start_server { |ws|
         ws.onopen {}
         ws.onclose {
-          ws.state.should == :closed
+          expect(ws.state).to eq :closed
           EventMachine.stop
         }
       }
@@ -101,8 +101,8 @@ describe "WebSocket server draft75" do
         ws.onopen { fail }
         ws.onclose { EventMachine.stop }
         ws.onerror {|e|
-          e.should be_an_instance_of EventMachine::WebSocket::HandshakeError
-          e.message.should match('Not an upgrade request')
+          expect(e).to be_an_instance_of EventMachine::WebSocket::HandshakeError
+          expect(e.message).to match('Not an upgrade request')
           EventMachine.stop
         }
       }
@@ -113,7 +113,7 @@ describe "WebSocket server draft75" do
     em {
       start_server { |ws|
         ws.onopen {
-          ws.supports_close_codes?.should == false
+          expect(ws.supports_close_codes?).to eq false
           done
         }
       }

--- a/spec/integration/draft76_spec.rb
+++ b/spec/integration/draft76_spec.rb
@@ -52,8 +52,8 @@ describe "WebSocket server draft76" do
 
       start_client { |connection|
         connection.onopen {
-          connection.handshake_response.lines.sort.
-            should == format_response(@response).lines.sort
+          expect(connection.handshake_response.lines.sort)
+            .to eq format_response(@response).lines.sort
           done
         }
       }
@@ -74,8 +74,7 @@ describe "WebSocket server draft76" do
       # Check that this causes a termination string to be returned and the
       # connection close
       connection.onclose {
-        connection.packets[0].should ==
-          EM::WebSocket::Handler76::TERMINATE_STRING
+        expect(connection.packets[0]).to eq EM::WebSocket::Handler76::TERMINATE_STRING
         done
       }
     }
@@ -108,7 +107,7 @@ describe "WebSocket server draft76" do
     em {
       start_server { |ws|
         ws.onmessage { |msg|
-          msg.should == "\n\000"
+          expect(msg).to eq "\n\000"
         }
       }
 
@@ -130,8 +129,8 @@ describe "WebSocket server draft76" do
     em {
       start_server { |server|
         server.onerror { |error|
-          error.should be_an_instance_of EM::WebSocket::WSMessageTooBigError
-          error.message.should == "Frame length too long (1180591620717411303296 bytes)"
+          expect(error).to be_an_instance_of EM::WebSocket::WSMessageTooBigError
+          expect(error.message).to eq "Frame length too long (1180591620717411303296 bytes)"
           done
         }
       }
@@ -152,8 +151,8 @@ describe "WebSocket server draft76" do
     em {
       start_server { |server|
         server.onerror { |error|
-          error.should be_an_instance_of EM::WebSocket::WSProtocolError
-          error.message.should == "Invalid frame received"
+          expect(error).to be_an_instance_of EM::WebSocket::WSProtocolError
+          expect(error.message).to eq "Invalid frame received"
           done
         }
       }
@@ -170,8 +169,8 @@ describe "WebSocket server draft76" do
     em {
       start_server { |server|
         server.onerror { |error|
-          error.should be_an_instance_of EM::WebSocket::HandshakeError
-          error.message.should == "Invalid HTTP header: Could not parse data entirely (1 != 29)"
+          expect(error).to be_an_instance_of EM::WebSocket::HandshakeError
+          expect(error.message).to eq "Invalid HTTP header: Could not parse data entirely (1 != 29)"
           done
         }
       }
@@ -192,8 +191,8 @@ describe "WebSocket server draft76" do
       connection.send_data(data[0...(data.length / 2)])
 
       connection.onopen {
-        connection.handshake_response.lines.sort.
-          should == format_response(@response).lines.sort
+        expect(connection.handshake_response.lines.sort)
+          .to eq format_response(@response).lines.sort
         done
       }
 
@@ -208,7 +207,7 @@ describe "WebSocket server draft76" do
     em {
       start_server { |ws|
         ws.onopen {
-          ws.supports_close_codes?.should == false
+          expect(ws.supports_close_codes?).to eq false
           done
         }
       }

--- a/spec/integration/gte_03_examples.rb
+++ b/spec/integration/gte_03_examples.rb
@@ -13,8 +13,8 @@ shared_examples_for "a WebSocket server drafts 3 and above" do
         
         ws.onerror { |e|
           # 3: Client should receive onerror
-          e.class.should == EM::WebSocket::WSProtocolError
-          e.message.should == "Close handshake un-acked after 0.1s, closing tcp connection"
+          expect(e.class).to eq EM::WebSocket::WSProtocolError
+          expect(e.message).to eq "Close handshake un-acked after 0.1s, closing tcp connection"
           server_onerror_fired = true
         }
         
@@ -26,14 +26,14 @@ shared_examples_for "a WebSocket server drafts 3 and above" do
         client.onmessage { |msg|
           # 2: Client does not respond to close handshake (the fake client 
           # doesn't understand them at all hence this is in onmessage)
-          msg.should =~ /Close message/ if version >= 6
+          expect(msg).to match /Close message/ if version >= 6
           client_got_close_handshake = true
         }
         
         client.onclose {
-          server_onerror_fired.should == true
-          server_onclose_fired.should == true
-          client_got_close_handshake.should == true
+          expect(server_onerror_fired).to eq true
+          expect(server_onclose_fired).to eq true
+          expect(client_got_close_handshake).to eq true
           done
         }
       }

--- a/spec/integration/shared_examples.rb
+++ b/spec/integration/shared_examples.rb
@@ -7,7 +7,7 @@ shared_examples_for "a websocket server" do
     em {
       start_server { |ws|
         ws.onopen { |handshake|
-          handshake.protocol_version.should == version
+          expect(handshake.protocol_version).to eq version
           done
         }
       }
@@ -20,7 +20,7 @@ shared_examples_for "a websocket server" do
     em {
       start_server { |ws|
         ws.onopen { |handshake|
-          handshake.origin.should == 'http://example.com'
+          expect(handshake.origin).to eq 'http://example.com'
           done
         }
       }
@@ -33,7 +33,7 @@ shared_examples_for "a websocket server" do
     em {
       start_server { |ws|
         ws.onopen {
-          ws.remote_ip.should == "127.0.0.1"
+          expect(ws.remote_ip).to eq "127.0.0.1"
           done
         }
       }
@@ -46,7 +46,7 @@ shared_examples_for "a websocket server" do
     em {
       start_server { |ws|
         ws.onmessage { |message|
-          message.should == "hello server"
+          expect(message).to eq "hello server"
           done
         }
       }
@@ -78,9 +78,9 @@ shared_examples_for "a websocket server" do
     em {
       start_server { |ws|
         ws.onopen {
-          lambda {
+          expect {
             ws.close(2000)
-          }.should raise_error("Application code may only use codes from 1000, 3000-4999")
+          }.to raise_error("Application code may only use codes from 1000, 3000-4999")
           done
         }
       }
@@ -97,7 +97,7 @@ shared_examples_for "a websocket server" do
           ws.close_connection
         }
         ws.onclose { |event|
-          event.should == {:code => 1006, :was_clean => false}
+          expect(event).to eq({:code => 1006, :was_clean => false})
           done
         }
       }
@@ -109,7 +109,7 @@ shared_examples_for "a websocket server" do
     em {
       start_server { |ws|
         ws.onclose { |event|
-          event.should == {:code => 1006, :was_clean => false}
+          expect(event).to eq({:code => 1006, :was_clean => false})
           done
         }
       }
@@ -130,7 +130,7 @@ shared_examples_for "a websocket server" do
         }
 
         ws.onerror { |e|
-          e.message.should == "application error"
+          expect(e.message).to eq "application error"
           done
         }
       }
@@ -147,7 +147,7 @@ shared_examples_for "a websocket server" do
         }
 
         server.onerror { |e|
-          e.message.should == "application error"
+          expect(e.message).to eq "application error"
           done
         }
       }
@@ -168,7 +168,7 @@ shared_examples_for "a websocket server" do
         }
 
         server.onerror { |e|
-          e.message.should == "application error"
+          expect(e.message).to eq "application error"
           done
         }
       }
@@ -190,8 +190,8 @@ shared_examples_for "a websocket server" do
 
         server.onerror { |e|
           # 3: Error should be reported to server
-          e.class.should == EventMachine::WebSocket::WSMessageTooBigError
-          e.message.should =~ /Frame length too long/
+          expect(e.class).to eq EventMachine::WebSocket::WSMessageTooBigError
+          expect(e.message).to match /Frame length too long/
         }
       }
 
@@ -228,14 +228,14 @@ shared_examples_for "a websocket server" do
             s = "ê" # utf-8 string
             s.encode!("ISO-8859-1")
             s.force_encoding("UTF-8")
-            s.valid_encoding?.should == false # now invalid utf8
+            expect(s.valid_encoding?).to eq false # now invalid utf8
 
             # Send non utf8 encoded data
             server.send(s)
           }
           server.onerror { |error|
-            error.class.should == EventMachine::WebSocket::WebSocketError
-            error.message.should == "Data sent to WebSocket must be valid UTF-8 but was UTF-8 (valid: false)"
+            expect(error.class).to eq EventMachine::WebSocket::WebSocketError
+            expect(error.message).to eq "Data sent to WebSocket must be valid UTF-8 but was UTF-8 (valid: false)"
             done
           }
         }
@@ -253,7 +253,7 @@ shared_examples_for "a websocket server" do
 
             server.send(s)
 
-            s.encoding.should == Encoding.find("UTF-8")
+            expect(s.encoding).to eq Encoding.find("UTF-8")
             done
           }
         }

--- a/spec/unit/framing_spec.rb
+++ b/spec/unit/framing_spec.rb
@@ -28,32 +28,32 @@ describe EM::WebSocket::Framing03 do
   
   describe "basic examples" do
     it "connection close" do
-      @f.should_receive(:message).with(:close, '', '')
+      expect(@f).to receive(:message).with(:close, '', '')
       @f << 0b00000001
       @f << 0b00000000
     end
     
     it "ping" do
-      @f.should_receive(:message).with(:ping, '', '')
+      expect(@f).to receive(:message).with(:ping, '', '')
       @f << 0b00000010
       @f << 0b00000000
     end
     
     it "pong" do
-      @f.should_receive(:message).with(:pong, '', '')
+      expect(@f).to receive(:message).with(:pong, '', '')
       @f << 0b00000011
       @f << 0b00000000
     end
     
     it "text" do
-      @f.should_receive(:message).with(:text, '', 'foo')
+      expect(@f).to receive(:message).with(:text, '', 'foo')
       @f << 0b00000100
       @f << 0b00000011
       @f << 'foo'
     end
     
     it "Text in two frames" do
-      @f.should_receive(:message).with(:text, '', 'hello world')
+      expect(@f).to receive(:message).with(:text, '', 'hello world')
       @f << 0b10000100
       @f << 0b00000110
       @f << "hello "
@@ -64,7 +64,7 @@ describe EM::WebSocket::Framing03 do
     
     it "2 byte extended payload length text frame" do
       data = 'a' * 256
-      @f.should_receive(:message).with(:text, '', data)
+      expect(@f).to receive(:message).with(:text, '', data)
       @f << 0b00000100 # Single frame, text
       @f << 0b01111110 # Length 126 (so read 2 bytes)
       @f << 0b00000001 # Two bytes in network byte order (256)
@@ -77,37 +77,37 @@ describe EM::WebSocket::Framing03 do
   # http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-03#section-4.6
   describe "examples from the spec" do
     it "a single-frame text message" do
-      @f.should_receive(:message).with(:text, '', 'Hello')
+      expect(@f).to receive(:message).with(:text, '', 'Hello')
       @f << "\x04\x05Hello"
     end
     
     it "a fragmented text message" do
-      @f.should_receive(:message).with(:text, '', 'Hello')
+      expect(@f).to receive(:message).with(:text, '', 'Hello')
       @f << "\x84\x03Hel"
       @f << "\x00\x02lo"
     end
     
     it "Ping request and response" do
-      @f.should_receive(:message).with(:ping, '', 'Hello')
+      expect(@f).to receive(:message).with(:ping, '', 'Hello')
       @f << "\x02\x05Hello"
     end
     
     it "256 bytes binary message in a single frame" do
       data = "a"*256
-      @f.should_receive(:message).with(:binary, '', data)
+      expect(@f).to receive(:message).with(:binary, '', data)
       @f << "\x05\x7E\x01\x00" + data
     end
     
     it "64KiB binary message in a single frame" do
       data = "a"*65536
-      @f.should_receive(:message).with(:binary, '', data)
+      expect(@f).to receive(:message).with(:binary, '', data)
       @f << "\x05\x7F\x00\x00\x00\x00\x00\x01\x00\x00" + data
     end
   end
 
   describe "other tests" do
     it "should accept a fragmented unmasked text message in 3 frames" do
-      @f.should_receive(:message).with(:text, '', 'Hello world')
+      expect(@f).to receive(:message).with(:text, '', 'Hello world')
       @f << "\x84\x03Hel"
       @f << "\x80\x02lo"
       @f << "\x00\x06 world"
@@ -116,11 +116,11 @@ describe EM::WebSocket::Framing03 do
 
   describe "error cases" do
     it "should raise an exception on continuation frame without preceeding more frame" do
-      lambda {
+      expect {
         @f << 0b00000000 # Single frame, continuation
         @f << 0b00000001 # Length 1
         @f << 'f'
-      }.should raise_error(EM::WebSocket::WebSocketError, 'Continuation frame not expected')
+      }.to raise_error(EM::WebSocket::WebSocketError, 'Continuation frame not expected')
     end
   end
 end
@@ -153,42 +153,42 @@ describe EM::WebSocket::Framing04 do
 
   describe "examples from the spec" do
     it "a single-frame text message" do
-      @f.should_receive(:message).with(:text, '', 'Hello')
+      expect(@f).to receive(:message).with(:text, '', 'Hello')
       @f << "\x84\x05\x48\x65\x6c\x6c\x6f" # "\x84\x05Hello"
     end
 
     it "a fragmented text message" do
-      @f.should_receive(:message).with(:text, '', 'Hello')
+      expect(@f).to receive(:message).with(:text, '', 'Hello')
       @f << "\x04\x03Hel"
       @f << "\x80\x02lo"
     end
 
     it "Ping request" do
-      @f.should_receive(:message).with(:ping, '', 'Hello')
+      expect(@f).to receive(:message).with(:ping, '', 'Hello')
       @f << "\x82\x05Hello"
     end
 
     it "a pong response" do
-      @f.should_receive(:message).with(:pong, '', 'Hello')
+      expect(@f).to receive(:message).with(:pong, '', 'Hello')
       @f << "\x83\x05Hello"
     end
 
     it "256 bytes binary message in a single frame" do
       data = "a"*256
-      @f.should_receive(:message).with(:binary, '', data)
+      expect(@f).to receive(:message).with(:binary, '', data)
       @f << "\x85\x7E\x01\x00" + data
     end
 
     it "64KiB binary message in a single frame" do
       data = "a"*65536
-      @f.should_receive(:message).with(:binary, '', data)
+      expect(@f).to receive(:message).with(:binary, '', data)
       @f << "\x85\x7F\x00\x00\x00\x00\x00\x01\x00\x00" + data
     end
   end
 
   describe "other tests" do
     it "should accept a fragmented unmasked text message in 3 frames" do
-      @f.should_receive(:message).with(:text, '', 'Hello world')
+      expect(@f).to receive(:message).with(:text, '', 'Hello world')
       @f << "\x04\x03Hel"
       @f << "\x00\x02lo"
       @f << "\x80\x06 world"
@@ -224,75 +224,75 @@ describe EM::WebSocket::Framing07 do
   # http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-07#section-4.6
   describe "examples from the spec" do
     it "a single-frame unmakedtext message" do
-      @f.should_receive(:message).with(:text, '', 'Hello')
+      expect(@f).to receive(:message).with(:text, '', 'Hello')
       @f << "\x81\x05\x48\x65\x6c\x6c\x6f" # "\x84\x05Hello"
     end
 
     it "a single-frame masked text message" do
-      @f.should_receive(:message).with(:text, '', 'Hello')
+      expect(@f).to receive(:message).with(:text, '', 'Hello')
       @f << "\x81\x85\x37\xfa\x21\x3d\x7f\x9f\x4d\x51\x58" # "\x84\x05Hello"
     end
 
     it "a fragmented unmasked text message" do
-      @f.should_receive(:message).with(:text, '', 'Hello')
+      expect(@f).to receive(:message).with(:text, '', 'Hello')
       @f << "\x01\x03Hel"
       @f << "\x80\x02lo"
     end
 
     it "Ping request" do
-      @f.should_receive(:message).with(:ping, '', 'Hello')
+      expect(@f).to receive(:message).with(:ping, '', 'Hello')
       @f << "\x89\x05Hello"
     end
 
     it "a pong response" do
-      @f.should_receive(:message).with(:pong, '', 'Hello')
+      expect(@f).to receive(:message).with(:pong, '', 'Hello')
       @f << "\x8a\x05Hello"
     end
 
     it "256 bytes binary message in a single unmasked frame" do
       data = "a"*256
-      @f.should_receive(:message).with(:binary, '', data)
+      expect(@f).to receive(:message).with(:binary, '', data)
       @f << "\x82\x7E\x01\x00" + data
     end
 
     it "64KiB binary message in a single unmasked frame" do
       data = "a"*65536
-      @f.should_receive(:message).with(:binary, '', data)
+      expect(@f).to receive(:message).with(:binary, '', data)
       @f << "\x82\x7F\x00\x00\x00\x00\x00\x01\x00\x00" + data
     end
   end
 
   describe "other tests" do
     it "should raise a WSProtocolError if an invalid frame type is requested" do
-      lambda {
+      expect {
         # Opcode 3 is not supported by this draft
         @f << "\x83\x05Hello"
-      }.should raise_error(EventMachine::WebSocket::WSProtocolError, "Unknown opcode 3")
+      }.to raise_error(EventMachine::WebSocket::WSProtocolError, "Unknown opcode 3")
     end
 
     it "should accept a fragmented unmasked text message in 3 frames" do
-      @f.should_receive(:message).with(:text, '', 'Hello world')
+      expect(@f).to receive(:message).with(:text, '', 'Hello world')
       @f << "\x01\x03Hel"
       @f << "\x00\x02lo"
       @f << "\x80\x06 world"
     end
 
     it "should raise if non-fin frame is followed by a non-continuation data frame (continuation frame would be expected)" do
-      lambda {
+      expect {
         @f << 0b00000001 # Not fin, text
         @f << 0b00000001 # Length 1
         @f << 'f'
         @f << 0b10000001 # fin, text (continutation expected)
         @f << 0b00000001 # Length 1
         @f << 'b'
-      }.should raise_error(EM::WebSocket::WebSocketError, 'Continuation frame expected')
+      }.to raise_error(EM::WebSocket::WebSocketError, 'Continuation frame expected')
     end
 
     it "should raise on non-fin control frames (control frames must not be fragmented)" do
-      lambda {
+      expect {
         @f << 0b00001010 # Not fin, pong (opcode 10)
         @f << 0b00000000 # Length 1
-      }.should raise_error(EM::WebSocket::WebSocketError, 'Control frames must not be fragmented')
+      }.to raise_error(EM::WebSocket::WebSocketError, 'Control frames must not be fragmented')
     end
   end
 end

--- a/spec/unit/handshake_spec.rb
+++ b/spec/unit/handshake_spec.rb
@@ -39,17 +39,17 @@ describe EM::WebSocket::Handshake do
   end
   
   it "should handle good request" do
-    handshake(@request).should succeed_with_upgrade(@response)
+    expect(handshake(@request)).to succeed_with_upgrade(@response)
   end
   
   it "should handle good request to secure default port if secure mode is enabled" do
-    handshake(@secure_request, true).
-      should succeed_with_upgrade(@secure_response)
+    expect(handshake(@secure_request, true))
+      .to succeed_with_upgrade(@secure_response)
   end
   
   it "should not handle good request to secure default port if secure mode is disabled" do
-    handshake(@secure_request, false).
-      should_not succeed_with_upgrade(@secure_response)
+    expect(handshake(@secure_request, false))
+      .to_not succeed_with_upgrade(@secure_response)
   end
   
   it "should handle good request on nondefault port" do
@@ -58,7 +58,7 @@ describe EM::WebSocket::Handshake do
     @response[:headers]['Sec-WebSocket-Location'] =
       'ws://example.com:8081/demo'
 
-    handshake(@request).should succeed_with_upgrade(@response)
+    expect(handshake(@request)).to succeed_with_upgrade(@response)
   end
   
   it "should handle good request to secure nondefault port" do
@@ -66,22 +66,22 @@ describe EM::WebSocket::Handshake do
     @secure_request[:headers]['Host'] = 'example.com:8081'
     @secure_response[:headers]['Sec-WebSocket-Location'] = 'wss://example.com:8081/demo'
     
-    handshake(@secure_request, true).
-      should succeed_with_upgrade(@secure_response)
+    expect(handshake(@secure_request, true))
+      .to succeed_with_upgrade(@secure_response)
   end
   
   it "should handle good request with no protocol" do
     @request[:headers].delete('Sec-WebSocket-Protocol')
     @response[:headers].delete("Sec-WebSocket-Protocol")
 
-    handshake(@request).should succeed_with_upgrade(@response)
+    expect(handshake(@request)).to succeed_with_upgrade(@response)
   end
   
   it "should handle extra headers by simply ignoring them" do
     @request[:headers]['EmptyValue'] = ""
     @request[:headers]['AKey'] = "AValue"
 
-    handshake(@request).should succeed_with_upgrade(@response)
+    expect(handshake(@request)).to succeed_with_upgrade(@response)
   end
   
   it "should raise error on HTTP request" do
@@ -96,33 +96,33 @@ describe EM::WebSocket::Handshake do
       'Connection' => 'keep-alive',
     }
     
-    handshake(@request).should fail_with_error(EM::WebSocket::HandshakeError)
+    expect(handshake(@request)).to fail_with_error(EM::WebSocket::HandshakeError)
   end
   
   it "should raise error on wrong method" do
     @request[:method] = 'POST'
 
-    handshake(@request).should fail_with_error(EM::WebSocket::HandshakeError)
+    expect(handshake(@request)).to fail_with_error(EM::WebSocket::HandshakeError)
   end
   
   it "should raise error if upgrade header incorrect" do
     @request[:headers]['Upgrade'] = 'NonWebSocket'
 
-    handshake(@request).should fail_with_error(EM::WebSocket::HandshakeError)
+    expect(handshake(@request)).to fail_with_error(EM::WebSocket::HandshakeError)
   end
   
   it "should raise error if Sec-WebSocket-Protocol is empty" do
     @request[:headers]['Sec-WebSocket-Protocol'] = ''
 
-    handshake(@request).should fail_with_error(EM::WebSocket::HandshakeError)
+    expect(handshake(@request)).to fail_with_error(EM::WebSocket::HandshakeError)
   end
   
   %w[Sec-WebSocket-Key1 Sec-WebSocket-Key2].each do |header|
     it "should raise error if #{header} has zero spaces" do
       @request[:headers][header] = 'nospaces'
 
-      handshake(@request).
-        should fail_with_error(EM::WebSocket::HandshakeError, 'Websocket Key1 or Key2 does not contain spaces - this is a symptom of a cross-protocol attack')
+      expect(handshake(@request))
+        .to fail_with_error(EM::WebSocket::HandshakeError, 'Websocket Key1 or Key2 does not contain spaces - this is a symptom of a cross-protocol attack')
     end
   end
   
@@ -132,30 +132,30 @@ describe EM::WebSocket::Handshake do
     # The error message isn't correct since key1 is used to heuristically
     # determine the protocol version in use, however this test at least checks
     # that the handshake does correctly fail
-    handshake(@request).
-      should fail_with_error(EM::WebSocket::HandshakeError, 'Extra bytes after header')
+    expect(handshake(@request))
+      .to fail_with_error(EM::WebSocket::HandshakeError, 'Extra bytes after header')
   end
 
   it "should raise error if Sec-WebSocket-Key2 is missing" do
     @request[:headers].delete("Sec-WebSocket-Key2")
 
-    handshake(@request).
-      should fail_with_error(EM::WebSocket::HandshakeError, 'WebSocket key1 or key2 is missing')
+    expect(handshake(@request))
+      .to fail_with_error(EM::WebSocket::HandshakeError, 'WebSocket key1 or key2 is missing')
   end
 
   it "should raise error if spaces do not divide numbers in Sec-WebSocket-Key* " do
     @request[:headers]['Sec-WebSocket-Key2'] = '12998 5 Y3 1.P00'
 
-    handshake(@request).
-      should fail_with_error(EM::WebSocket::HandshakeError, 'Invalid Key "12998 5 Y3 1.P00"')
+    expect(handshake(@request))
+      .to fail_with_error(EM::WebSocket::HandshakeError, 'Invalid Key "12998 5 Y3 1.P00"')
   end
   
   it "should raise error if the HTTP header is empty" do
     handshake = EM::WebSocket::Handshake.new(false)
     handshake.receive_data("\r\n\r\nfoobar")
     
-    handshake.
-      should fail_with_error(EM::WebSocket::HandshakeError, 'Invalid HTTP header: Could not parse data entirely (4 != 10)')
+    expect(handshake)
+      .to fail_with_error(EM::WebSocket::HandshakeError, 'Invalid HTTP header: Could not parse data entirely (4 != 10)')
   end
 
   # This might seems crazy, but very occasionally we saw multiple "Upgrade:
@@ -172,8 +172,8 @@ describe EM::WebSocket::Handshake do
     handshake.receive_data(headers)
 
     handshake.errback { |e|
-      e.class.should == EM::WebSocket::HandshakeError
-      e.message.should == 'Invalid upgrade header: ["WebSocket", "WebSocket"]'
+      expect(e.class).to eq EM::WebSocket::HandshakeError
+      expect(e.message).to eq 'Invalid upgrade header: ["WebSocket", "WebSocket"]'
     }
   end
   
@@ -184,12 +184,12 @@ describe EM::WebSocket::Handshake do
     handshake = EM::WebSocket::Handshake.new(false)
     handshake.receive_data(incomplete_request)
     
-    handshake.instance_variable_get(:@deferred_status).should == nil
+    expect(handshake.instance_variable_get(:@deferred_status)).to eq nil
     
     # Send the remaining header
     handshake.receive_data(rest)
     
-    handshake(@request).should succeed_with_upgrade(@response)
+    expect(handshake(@request)).to succeed_with_upgrade(@response)
   end
   
   it "should cope with requests where the third key is split" do
@@ -200,17 +200,17 @@ describe EM::WebSocket::Handshake do
     handshake = EM::WebSocket::Handshake.new(false)
     handshake.receive_data(incomplete_request)
     
-    handshake.instance_variable_get(:@deferred_status).should == nil
+    expect(handshake.instance_variable_get(:@deferred_status)).to eq nil
     
     # Send the remaining third key
     handshake.receive_data(rest)
     
-    handshake(@request).should succeed_with_upgrade(@response)
+    expect(handshake(@request)).to succeed_with_upgrade(@response)
   end
 
   it "should fail if the request URI is invalid" do
     @request[:path] = "/%"
-    handshake(@request).should \
+    expect(handshake(@request)).to \
       fail_with_error(EM::WebSocket::HandshakeError, 'Invalid request URI: /%')
   end
 end

--- a/spec/unit/masking_spec.rb
+++ b/spec/unit/masking_spec.rb
@@ -6,24 +6,24 @@ describe EM::WebSocket::MaskedString do
   it "should allow reading 4 byte mask and unmasking byte / bytes" do
     t = EM::WebSocket::MaskedString.new("\x00\x00\x00\x01\x00\x01\x00\x01")
     t.read_mask
-    t.getbyte(3).should == 0x00
-    t.getbytes(4, 4).should == "\x00\x01\x00\x00"
-    t.getbytes(5, 3).should ==     "\x01\x00\x00"
+    expect(t.getbyte(3)).to eq 0x00
+    expect(t.getbytes(4, 4)).to eq "\x00\x01\x00\x00"
+    expect(t.getbytes(5, 3)).to eq "\x01\x00\x00"
   end
 
   it "should return nil from getbyte if index requested is out of range" do
     t = EM::WebSocket::MaskedString.new("\x00\x00\x00\x00\x53")
     t.read_mask
-    t.getbyte(4).should == 0x53
-    t.getbyte(5).should == nil
+    expect(t.getbyte(4)).to eq 0x53
+    expect(t.getbyte(5)).to eq nil
   end
   
   it "should allow switching masking on and off" do
     t = EM::WebSocket::MaskedString.new("\x02\x00\x00\x00\x03")
-    t.getbyte(4).should == 0x03
+    expect(t.getbyte(4)).to eq 0x03
     t.read_mask
-    t.getbyte(4).should == 0x01
+    expect(t.getbyte(4)).to eq 0x01
     t.unset_mask
-    t.getbyte(4).should == 0x03
+    expect(t.getbyte(4)).to eq 0x03
   end
 end


### PR DESCRIPTION
This Pull Request adds GitHub Actions CI to run tests across different Ruby versions.

The Ruby versions targeted by CI range from 3.3 to 2.4.
The minimum version is set to 2.4 to align with the `required_ruby_version` of the `base64` gem in the PR (#161).

Additionally, this PR includes fixes to run rspec on Ruby 3.2 or higher.
